### PR TITLE
fix(metg): fixed wrong files on WJS's Super Sledge Ported info

### DIFF
--- a/docs/METG - Melee Weapon Retextures.md
+++ b/docs/METG - Melee Weapon Retextures.md
@@ -89,7 +89,8 @@ Complete model and texture replacement for Super Sledge & Super Sledge Unique (O
 Select the **Filetree** tab and find the files `SuperSledgebyWJS_Collection.esp` & `SuperSledgebyWJS_Replacer.esp` then right click and select **Hide**.
 
 ```
-📄 LaserRifleReplacer.esp  ⟵ right click and select Hide
+📄 SuperSledgebyWJS_Collection.esp  ⟵ right click and select Hide
+📄 SuperSledgebyWJS_Replacer.esp  ⟵ right click and select Hide
 ```
 
 :::


### PR DESCRIPTION
it was using the same file as Laser Rifle Replacer on diagram, causing misconceptions in info interpretation